### PR TITLE
[Feat] 40 : 경기등록 기능 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,23 +7,47 @@ import DropDown from '@/components/common/DropDown'
 import Icon from '@/components/common/Icon'
 import MatchInfoCard from '@/components/MatchInfoCard'
 import Modal from '@/components/common/Modal'
-import type { PostMatchData } from '@/constants/modal'
 import Button from '@/components/common/Button'
+
+// ▼ 추가: 모달 타입/프롭(프로젝트 정의에 맞춰 import)
+import type {
+  PostMatchData, // Step1 데이터 { date, opponent, place, score }
+  RosterData, // Step2 데이터 { formation, GK, DF, MF, FW }
+  QuarterData, // Step3 데이터 { goals[], conceded, scoreAfter }
+  ModalVariant,
+} from '@/constants/modal'
 
 type SortOrder = 'latest' | 'oldest'
 
+// ▼ 예시 플레이어(나중에 실제 데이터로 대체)
+const players = [
+  { id: 'u1', name: '김GK', position: 'GK' as const },
+  { id: 'u2', name: '박DF', position: 'DF' as const },
+  { id: 'u3', name: '이DF', position: 'DF' as const },
+  { id: 'u4', name: '최MF', position: 'MF' as const },
+  { id: 'u5', name: '정MF', position: 'MF' as const },
+  { id: 'u6', name: '한FW', position: 'FW' as const },
+  { id: 'u7', name: '문FW', position: 'FW' as const },
+]
+
 export default function Home() {
-  // 목록을 로컬 상태로 복사해서 관리 (모달 등록 시 여기로 push)
   const [items, setItems] = useState([...MOCKS])
-  const [isOpen, setIsOpen] = useState(false)
+
+  // ▼ 멀티스텝 모달 상태
+  const [variant, setVariant] = useState<ModalVariant | null>(null)
+  const openStep1 = () => setVariant('postMatch')
+
+  // ▼ 스텝 데이터 (등록 페이로드 임시 보관)
+  const [step1, setStep1] = useState<PostMatchData | null>(null)
+  const [step2, setStep2] = useState<RosterData | null>(null)
+  const [step3, setStep3] = useState<QuarterData[] | null>(null)
+
+  // ▼ 검색/정렬/페이지네이션 (기존 그대로)
   const [page, setPage] = useState(1)
   const [query, setQuery] = useState('')
   const [sortOrder, setSortOrder] = useState<SortOrder>('latest')
   const PAGE_SIZE = 5
-
   const handleSubmitSearch = () => setPage(1)
-
-  // 검색
   const q = query.trim().toLowerCase()
   const filtered = useMemo(
     () =>
@@ -32,42 +56,64 @@ export default function Home() {
         : items,
     [items, q]
   )
-
-  // 정렬
   const sorted = useMemo(() => {
     const copy = [...filtered]
-    copy.sort((a, b) => {
-      const da = new Date(a.date).getTime()
-      const db = new Date(b.date).getTime()
-      return sortOrder === 'latest' ? db - da : da - db
-    })
+    copy.sort((a, b) =>
+      sortOrder === 'latest'
+        ? new Date(b.date).getTime() - new Date(a.date).getTime()
+        : new Date(a.date).getTime() - new Date(b.date).getTime()
+    )
     return copy
   }, [filtered, sortOrder])
-
-  // 페이지네이션 계산
   const totalCount = sorted.length
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
   const safePage = Math.min(page, totalPages)
   const start = (safePage - 1) * PAGE_SIZE
   const current = sorted.slice(start, start + PAGE_SIZE)
-
   useEffect(() => {
     setPage(1)
   }, [query, sortOrder])
 
-  // 모달 onSubmit → 로컬 목록에 추가
-  const handleCreateMatch = (data: PostMatchData) => {
-    // data: { date: 'YYYY-MM-DD', place, score, opponent }
-    // matchLocations mock에 맞춰 최소 필드 채워 넣기 (name은 opponent 기준 예시)
+  // Step1 완료 → Step2로
+  const handleStep1Submit = (data: PostMatchData) => {
+    setStep1(data)
+    setVariant('postRoster')
+  }
+
+  // Step2 완료 → Step3로
+  const handleStep2Submit = (data: RosterData) => {
+    setStep2(data)
+    setVariant('postQuarters')
+  }
+
+  // Step3 완료(최종) → 리스트 반영 + 모달 닫기
+  const handleStep3Submit = (quarters: QuarterData[]) => {
+    setStep3(quarters)
+
+    // 화면용 신규 아이템(간단 매핑) - 실제론 /matches/[id]로 라우팅 or Supabase insert 예정
     const nextId = (items.reduce((m, it) => Math.max(m, it.id), 0) || 0) + 1
     const newItem = {
       id: nextId,
-      name: data.opponent, // 예: 카드에서 팀명으로 사용한다면 opponent를 name에 매핑
-      address: data.place,
-      date: data.date,
+      name: step1?.opponent ?? '상대팀',
+      address: step1?.place ?? '-',
+      date: step1?.date ?? new Date().toISOString(),
     }
     setItems((prev) => [newItem, ...prev])
+
+    // 모달 종료 및 임시 데이터 초기화
+    setVariant(null)
+    setStep1(null)
+    setStep2(null)
+    setStep3(null)
   }
+
+  // Step2 → Step3에 넘길 득점/도움 후보(로스터 선택된 선수만)
+  const eligiblePlayers = useMemo(() => {
+    if (!step2) return []
+    const ids = new Set([...step2.GK, ...step2.DF, ...step2.MF, ...step2.FW])
+    return players.filter((p) => ids.has(p.id)).map((p) => ({ id: p.id, name: p.name }))
+  }, [step2])
+
   return (
     <main className="bg-primary-100 p-20">
       <SearchBar value={query} onChange={setQuery} onSubmit={handleSubmitSearch} />
@@ -90,7 +136,7 @@ export default function Home() {
         <Button
           variant="primary"
           className="rounded-[20px] txt-16_B w-250 md:w-500 h-47 px-12 py-4"
-          onClick={() => setIsOpen(true)}
+          onClick={openStep1}
         >
           경기 등록
         </Button>
@@ -116,14 +162,29 @@ export default function Home() {
           onPageChange={setPage}
         />
       </div>
-      {isOpen && (
+      {variant === 'postMatch' && (
+        <Modal variant="postMatch" onClose={() => setVariant(null)} onSubmit={handleStep1Submit} />
+      )}
+
+      {variant === 'postRoster' && (
         <Modal
-          variant="postMatch"
-          onClose={() => setIsOpen(false)}
-          onSubmit={(data) => {
-            handleCreateMatch(data)
-            setIsOpen(false)
-          }}
+          variant="postRoster"
+          onBack={() => setVariant('postMatch')}
+          onClose={() => setVariant(null)}
+          onSubmit={handleStep2Submit}
+          players={players}
+          initial={step2 ?? undefined}
+        />
+      )}
+
+      {variant === 'postQuarters' && (
+        <Modal
+          variant="postQuarters"
+          onBack={() => setVariant('postRoster')}
+          onClose={() => setVariant(null)}
+          onSubmit={handleStep3Submit}
+          eligiblePlayers={eligiblePlayers}
+          initial={step3 ?? undefined}
         />
       )}
     </main>

--- a/src/components/common/modal-contents/PostMatchContent.tsx
+++ b/src/components/common/modal-contents/PostMatchContent.tsx
@@ -98,7 +98,7 @@ export function PostMatchContent({ onClose, onSubmit }: PostMatchProps) {
           disabled={!isValid}
           onClick={submit}
         >
-          등록
+          다음
         </Button>
       </div>
     </div>

--- a/src/components/common/modal-contents/PostMatchContent.tsx
+++ b/src/components/common/modal-contents/PostMatchContent.tsx
@@ -35,7 +35,6 @@ export function PostMatchContent({ onClose, onSubmit }: PostMatchProps) {
     setTouched({ date: true, place: true, score: true, opponent: true })
     if (!isValid) return
     onSubmit({ date, opponent, place, score })
-    onClose()
   }
 
   return (

--- a/src/components/common/modal-contents/PostQuartersContent.tsx
+++ b/src/components/common/modal-contents/PostQuartersContent.tsx
@@ -1,11 +1,159 @@
-import { PostQuartersContentProps } from '@/constants/modal'
+'use client'
 
-export default function PostQuartersContent({
+import { useState } from 'react'
+import Button from '@/components/common/Button'
+import Input from '@/components/common/Input'
+import type { PostQuartersContentProps } from '@/constants/modal'
+
+type GoalEvent = { scorerId: string; assistId?: string | null }
+type Quarter = { goals: GoalEvent[]; conceded: number; scoreAfter: string }
+
+export default function PostQuarterContent({
   onBack,
   onClose,
   onSubmit,
   eligiblePlayers,
   initial,
 }: PostQuartersContentProps) {
-  return <div>세번쨰 모달</div>
+  // 초기값이 있으면 사용, 없으면 4쿼터 기본값
+  const [quarters, setQuarters] = useState<Quarter[]>(
+    initial ?? [
+      { goals: [], conceded: 0, scoreAfter: '' },
+      { goals: [], conceded: 0, scoreAfter: '' },
+      { goals: [], conceded: 0, scoreAfter: '' },
+      { goals: [], conceded: 0, scoreAfter: '' },
+    ]
+  )
+
+  const update = (qi: number, patch: Partial<Quarter>) => {
+    setQuarters((prev) => prev.map((q, i) => (i === qi ? { ...q, ...patch } : q)))
+  }
+
+  const addGoal = (qi: number) => {
+    const goals = [...quarters[qi].goals, { scorerId: '', assistId: null }]
+    update(qi, { goals })
+  }
+
+  const rmGoal = (qi: number, gi: number) => {
+    const goals = quarters[qi].goals.filter((_, i) => i !== gi)
+    update(qi, { goals })
+  }
+
+  // 간단 유효성: scoreAfter 필수, conceded >= 0, 득점자(선택된 경우)는 eligible 안에 있어야 함
+  const isValid = quarters.every(
+    (q) =>
+      q.scoreAfter.trim() &&
+      q.conceded >= 0 &&
+      q.goals.every((g) => !g.scorerId || eligiblePlayers.some((p) => p.id === g.scorerId))
+  )
+
+  const handleSubmit = () => {
+    if (!isValid) return
+    onSubmit(quarters)
+  }
+
+  return (
+    <div className="px-15 py-10 w-350 md:w-400">
+      <h2 className="text-lg font-bold mb-4 text-center">경기 등록 · 쿼터별 기록</h2>
+
+      {quarters.map((q, qi) => (
+        <div key={qi} className="border rounded p-3 mb-4">
+          <div className="flex items-center justify-between mb-2">
+            <div className="font-semibold">Q{qi + 1}</div>
+            <Button size="sm" variant="secondary" onClick={() => addGoal(qi)}>
+              득점 추가
+            </Button>
+          </div>
+
+          {q.goals.length === 0 && <p className="text-sm text-gray-500 mb-2">득점 이벤트 없음</p>}
+
+          {q.goals.map((g, gi) => (
+            <div key={gi} className="grid grid-cols-2 gap-2 items-center mb-2">
+              <div>
+                <label className="text-xs">득점자</label>
+                <select
+                  className="w-full border rounded p-2"
+                  value={g.scorerId}
+                  onChange={(e) => {
+                    const goals = [...q.goals]
+                    goals[gi] = { ...goals[gi], scorerId: e.target.value }
+                    update(qi, { goals })
+                  }}
+                >
+                  <option value="">선택</option>
+                  {eligiblePlayers.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="text-xs">도움자(옵션)</label>
+                <select
+                  className="w-full border rounded p-2"
+                  value={g.assistId ?? ''}
+                  onChange={(e) => {
+                    const v = e.target.value || null
+                    const goals = [...q.goals]
+                    goals[gi] = { ...goals[gi], assistId: v }
+                    update(qi, { goals })
+                  }}
+                >
+                  <option value="">없음</option>
+                  {eligiblePlayers.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="col-span-2 flex justify-end">
+                <Button size="sm" variant="secondary" onClick={() => rmGoal(qi, gi)}>
+                  삭제
+                </Button>
+              </div>
+            </div>
+          ))}
+
+          <Input
+            id={`scoreAfter-${qi}`}
+            label="쿼터 종료 스코어"
+            variant="input"
+            placeholder="예: 2 - 1"
+            value={q.scoreAfter}
+            onChange={(e) => update(qi, { scoreAfter: e.target.value })}
+          />
+          <Input
+            id={`conceded-${qi}`}
+            label="실점"
+            type="number"
+            variant="input"
+            value={q.conceded}
+            onChange={(e) => update(qi, { conceded: Math.max(0, Number(e.target.value)) })}
+          />
+        </div>
+      ))}
+
+      <div className="my-20 flex gap-5 justify-evenly">
+        <Button className="flex-1 py-2" size="lg" variant="secondary" onClick={onBack}>
+          이전
+        </Button>
+        <Button className="flex-1 py-2" size="lg" variant="secondary" onClick={onClose}>
+          취소
+        </Button>
+        <Button
+          className="flex-1 text-white py-2"
+          size="lg"
+          variant="primary"
+          disabled={!isValid}
+          onClick={handleSubmit}
+        >
+          등록
+        </Button>
+      </div>
+    </div>
+  )
 }

--- a/src/components/common/modal-contents/PostQuartersContent.tsx
+++ b/src/components/common/modal-contents/PostQuartersContent.tsx
@@ -1,3 +1,11 @@
-export default function PostQuartersContent() {
+import { PostQuartersContentProps } from '@/constants/modal'
+
+export default function PostQuartersContent({
+  onBack,
+  onClose,
+  onSubmit,
+  eligiblePlayers,
+  initial,
+}: PostQuartersContentProps) {
   return <div>세번쨰 모달</div>
 }

--- a/src/components/common/modal-contents/PostQuartersContent.tsx
+++ b/src/components/common/modal-contents/PostQuartersContent.tsx
@@ -54,18 +54,15 @@ export default function PostQuarterContent({
 
   return (
     <div className="px-15 py-10 w-350 md:w-400">
-      <h2 className="text-lg font-bold mb-4 text-center">경기 등록 · 쿼터별 기록</h2>
-
+      <h2 className="text-lg font-bold mb-4 text-center">쿼터별 기록</h2>
       {quarters.map((q, qi) => (
-        <div key={qi} className="border rounded p-3 mb-4">
-          <div className="flex items-center justify-between mb-2">
-            <div className="font-semibold">Q{qi + 1}</div>
-            <Button size="sm" variant="secondary" onClick={() => addGoal(qi)}>
-              득점 추가
+        <div key={qi} className="border border-gray-100 min-h-150 px-8 rounded-[16px] my-10">
+          <div className="flex items-center justify-between gap-10 p-8 mb-2">
+            <div className="font-semibold">{qi + 1} 쿼터</div>
+            <Button size="xs" variant="secondary" onClick={() => addGoal(qi)}>
+              득점 도움
             </Button>
           </div>
-
-          {q.goals.length === 0 && <p className="text-sm text-gray-500 mb-2">득점 이벤트 없음</p>}
 
           {q.goals.map((g, gi) => (
             <div key={gi} className="grid grid-cols-2 gap-2 items-center mb-2">
@@ -111,33 +108,36 @@ export default function PostQuarterContent({
               </div>
 
               <div className="col-span-2 flex justify-end">
-                <Button size="sm" variant="secondary" onClick={() => rmGoal(qi, gi)}>
+                <Button size="xs" variant="secondary" onClick={() => rmGoal(qi, gi)}>
                   삭제
                 </Button>
               </div>
             </div>
           ))}
-
-          <Input
-            id={`scoreAfter-${qi}`}
-            label="쿼터 종료 스코어"
-            variant="input"
-            placeholder="예: 2 - 1"
-            value={q.scoreAfter}
-            onChange={(e) => update(qi, { scoreAfter: e.target.value })}
-          />
-          <Input
-            id={`conceded-${qi}`}
-            label="실점"
-            type="number"
-            variant="input"
-            value={q.conceded}
-            onChange={(e) => update(qi, { conceded: Math.max(0, Number(e.target.value)) })}
-          />
+          <div className="flex flex-row justify-center gap-20 m-10">
+            <Input
+              id={`scoreAfter-${qi}`}
+              label="쿼터 스코어"
+              variant="input"
+              placeholder="예: 2 - 1"
+              value={q.scoreAfter}
+              onChange={(e) => update(qi, { scoreAfter: e.target.value })}
+              className="w-150 h-40"
+            />
+            <Input
+              id={`conceded-${qi}`}
+              label="실점"
+              type="number"
+              variant="input"
+              value={q.conceded}
+              onChange={(e) => update(qi, { conceded: Math.max(0, Number(e.target.value)) })}
+              className="w-150 h-40"
+            />
+          </div>
         </div>
       ))}
 
-      <div className="my-20 flex gap-5 justify-evenly">
+      <div className="my-10 flex gap-5 justify-evenly">
         <Button className="flex-1 py-2" size="lg" variant="secondary" onClick={onBack}>
           이전
         </Button>

--- a/src/components/common/modal-contents/PostQuartersContent.tsx
+++ b/src/components/common/modal-contents/PostQuartersContent.tsx
@@ -3,20 +3,15 @@
 import { useState } from 'react'
 import Button from '@/components/common/Button'
 import Input from '@/components/common/Input'
-import type { PostQuartersContentProps } from '@/constants/modal'
+import type { PostQuartersContentProps, QuarterData } from '@/constants/modal'
 
-type GoalEvent = { scorerId: string; assistId?: string | null }
-type Quarter = { goals: GoalEvent[]; conceded: number; scoreAfter: string }
-
-export default function PostQuarterContent({
+export default function PostQuartersContent({
   onBack,
   onClose,
   onSubmit,
-  eligiblePlayers,
   initial,
 }: PostQuartersContentProps) {
-  // 초기값이 있으면 사용, 없으면 4쿼터 기본값
-  const [quarters, setQuarters] = useState<Quarter[]>(
+  const [quarters, setQuarters] = useState<QuarterData[]>(
     initial ?? [
       { goals: [], conceded: 0, scoreAfter: '' },
       { goals: [], conceded: 0, scoreAfter: '' },
@@ -25,96 +20,18 @@ export default function PostQuarterContent({
     ]
   )
 
-  const update = (qi: number, patch: Partial<Quarter>) => {
+  const update = (qi: number, patch: Partial<QuarterData>) => {
     setQuarters((prev) => prev.map((q, i) => (i === qi ? { ...q, ...patch } : q)))
   }
-
-  const addGoal = (qi: number) => {
-    const goals = [...quarters[qi].goals, { scorerId: '', assistId: null }]
-    update(qi, { goals })
-  }
-
-  const rmGoal = (qi: number, gi: number) => {
-    const goals = quarters[qi].goals.filter((_, i) => i !== gi)
-    update(qi, { goals })
-  }
-
-  // 간단 유효성: scoreAfter 필수, conceded >= 0, 득점자(선택된 경우)는 eligible 안에 있어야 함
-  const isValid = quarters.every(
-    (q) =>
-      q.scoreAfter.trim() &&
-      q.conceded >= 0 &&
-      q.goals.every((g) => !g.scorerId || eligiblePlayers.some((p) => p.id === g.scorerId))
-  )
-
-  const handleSubmit = () => {
-    if (!isValid) return
-    onSubmit(quarters)
-  }
+  const isValid = quarters.every((q) => q.scoreAfter.trim() && q.conceded >= 0)
 
   return (
     <div className="px-15 py-10 w-350 md:w-400">
-      <h2 className="text-lg font-bold mb-4 text-center">쿼터별 기록</h2>
+      <h2 className="text-lg font-bold mb-4 text-center">쿼터별 스코어 & 실점</h2>
       {quarters.map((q, qi) => (
-        <div key={qi} className="border border-gray-100 min-h-150 px-8 rounded-[16px] my-10">
-          <div className="flex items-center justify-between gap-10 p-8 mb-2">
-            <div className="font-semibold">{qi + 1} 쿼터</div>
-            <Button size="xs" variant="secondary" onClick={() => addGoal(qi)}>
-              득점 도움
-            </Button>
-          </div>
-
-          {q.goals.map((g, gi) => (
-            <div key={gi} className="grid grid-cols-2 gap-2 items-center mb-2">
-              <div>
-                <label className="text-xs">득점자</label>
-                <select
-                  className="w-full border rounded p-2"
-                  value={g.scorerId}
-                  onChange={(e) => {
-                    const goals = [...q.goals]
-                    goals[gi] = { ...goals[gi], scorerId: e.target.value }
-                    update(qi, { goals })
-                  }}
-                >
-                  <option value="">선택</option>
-                  {eligiblePlayers.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div>
-                <label className="text-xs">도움자(옵션)</label>
-                <select
-                  className="w-full border rounded p-2"
-                  value={g.assistId ?? ''}
-                  onChange={(e) => {
-                    const v = e.target.value || null
-                    const goals = [...q.goals]
-                    goals[gi] = { ...goals[gi], assistId: v }
-                    update(qi, { goals })
-                  }}
-                >
-                  <option value="">없음</option>
-                  {eligiblePlayers.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
-              <div className="col-span-2 flex justify-end">
-                <Button size="xs" variant="secondary" onClick={() => rmGoal(qi, gi)}>
-                  삭제
-                </Button>
-              </div>
-            </div>
-          ))}
-          <div className="flex flex-row justify-center gap-20 m-10">
+        <div key={qi} className="h-150 border border-gray-100 rounded-[16px] p-8 my-8">
+          <div className="font-semibold mb-6">{qi + 1}쿼터</div>
+          <div className="flex flex-row justify-center gap-20">
             <Input
               id={`scoreAfter-${qi}`}
               label="쿼터 스코어"
@@ -137,21 +54,21 @@ export default function PostQuarterContent({
         </div>
       ))}
 
-      <div className="my-10 flex gap-5 justify-evenly">
-        <Button className="flex-1 py-2" size="lg" variant="secondary" onClick={onBack}>
+      <div className="mt-10 flex gap-5 justify-evenly">
+        <Button className="flex-1" size="lg" variant="secondary" onClick={onBack}>
           이전
         </Button>
-        <Button className="flex-1 py-2" size="lg" variant="secondary" onClick={onClose}>
+        <Button className="flex-1" size="lg" variant="secondary" onClick={onClose}>
           취소
         </Button>
         <Button
-          className="flex-1 text-white py-2"
+          className="flex-1 text-white"
           size="lg"
           variant="primary"
           disabled={!isValid}
-          onClick={handleSubmit}
+          onClick={() => onSubmit(quarters)}
         >
-          등록
+          다음
         </Button>
       </div>
     </div>

--- a/src/components/common/modal-contents/PostQuartersContent.tsx
+++ b/src/components/common/modal-contents/PostQuartersContent.tsx
@@ -29,17 +29,17 @@ export default function PostQuartersContent({
     <div className="px-15 py-10 w-350 md:w-400">
       <h2 className="text-lg font-bold mb-4 text-center">쿼터별 스코어 & 실점</h2>
       {quarters.map((q, qi) => (
-        <div key={qi} className="h-150 border border-gray-100 rounded-[16px] p-8 my-8">
-          <div className="font-semibold mb-6">{qi + 1}쿼터</div>
+        <div key={qi} className="h-130 border border-gray-100 rounded-[16px] p-6 my-6">
+          <div className="font-semibold mb-4 text-center">{qi + 1} 쿼터</div>
           <div className="flex flex-row justify-center gap-20">
             <Input
               id={`scoreAfter-${qi}`}
               label="쿼터 스코어"
               variant="input"
-              placeholder="예: 2 - 1"
+              placeholder="예: 2-1"
               value={q.scoreAfter}
               onChange={(e) => update(qi, { scoreAfter: e.target.value })}
-              className="w-150 h-40"
+              className="w-150 h-30"
             />
             <Input
               id={`conceded-${qi}`}
@@ -48,7 +48,7 @@ export default function PostQuartersContent({
               variant="input"
               value={q.conceded}
               onChange={(e) => update(qi, { conceded: Math.max(0, Number(e.target.value)) })}
-              className="w-150 h-40"
+              className="w-150 h-30"
             />
           </div>
         </div>

--- a/src/components/common/modal-contents/PostQuartersContent.tsx
+++ b/src/components/common/modal-contents/PostQuartersContent.tsx
@@ -1,0 +1,3 @@
+export default function PostQuartersContent() {
+  return <div>세번쨰 모달</div>
+}

--- a/src/components/common/modal-contents/PostRosterContent.tsx
+++ b/src/components/common/modal-contents/PostRosterContent.tsx
@@ -1,3 +1,10 @@
-export default function PostRosterContent() {
+import { PostRosterContentProps } from '@/constants/modal'
+export default function PostRosterContent({
+  onBack,
+  onClose,
+  onSubmit,
+  players,
+  initial,
+}: PostRosterContentProps) {
   return <div>두번째 모달</div>
 }

--- a/src/components/common/modal-contents/PostRosterContent.tsx
+++ b/src/components/common/modal-contents/PostRosterContent.tsx
@@ -1,4 +1,15 @@
-import { PostRosterContentProps } from '@/constants/modal'
+'use client'
+
+import { useMemo, useState } from 'react'
+import Button from '@/components/common/Button'
+import type { PostRosterContentProps } from '@/constants/modal'
+
+// 포지션/포메이션 유틸
+const POSITIONS = ['GK', 'DF', 'MF', 'FW'] as const
+type Position = (typeof POSITIONS)[number]
+const FORMATIONS = ['4-4-2', '4-2-3-1'] as const
+type Formation = (typeof FORMATIONS)[number]
+
 export default function PostRosterContent({
   onBack,
   onClose,
@@ -6,5 +17,105 @@ export default function PostRosterContent({
   players,
   initial,
 }: PostRosterContentProps) {
-  return <div>두번째 모달</div>
+  // 초기값 세팅 (없으면 기본값)
+  const [formation, setFormation] = useState<Formation>(initial?.formation ?? '4-2-3-1')
+  const [roster, setRoster] = useState<Record<Position, string[]>>({
+    GK: initial?.GK ?? [],
+    DF: initial?.DF ?? [],
+    MF: initial?.MF ?? [],
+    FW: initial?.FW ?? [],
+  })
+
+  // 포지션별 선수 그룹
+  const grouped = useMemo(() => {
+    return {
+      GK: players.filter((p) => p.position === 'GK'),
+      DF: players.filter((p) => p.position === 'DF'),
+      MF: players.filter((p) => p.position === 'MF'),
+      FW: players.filter((p) => p.position === 'FW'),
+    }
+  }, [players])
+
+  // 선택 변경
+  const setPos = (pos: Position, ids: string[]) => setRoster((prev) => ({ ...prev, [pos]: ids }))
+
+  // 간단 검증: GK 최소 1명 (필요 시 포메이션별 정확 인원 수 검증 로직 추가 가능)
+  const isValid = roster.GK.length >= 1
+
+  const handleNext = () => {
+    if (!isValid) return
+    onSubmit({
+      formation,
+      GK: roster.GK,
+      DF: roster.DF,
+      MF: roster.MF,
+      FW: roster.FW,
+    })
+  }
+
+  return (
+    <div className="px-15 py-10 w-350 md:w-400">
+      <h2 className="text-lg font-bold mb-4 text-center">경기 등록 · 참석자/포메이션</h2>
+
+      <div className="flex flex-col gap-16">
+        {/* 포메이션 */}
+        <div>
+          <label className="block mb-1 text-sm font-medium">포메이션</label>
+          <select
+            className="w-full border rounded p-2"
+            value={formation}
+            onChange={(e) => setFormation(e.target.value as Formation)}
+          >
+            {FORMATIONS.map((f) => (
+              <option key={f} value={f}>
+                {f}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-500 mt-1">GK는 최소 1명을 선택해 주세요.</p>
+        </div>
+
+        {/* 포지션별 멀티선택 */}
+        {POSITIONS.map((pos) => (
+          <div key={pos}>
+            <label className="block mb-1 text-sm font-medium">{pos}</label>
+            <select
+              multiple
+              className="w-full border rounded p-2 min-h-[96px]"
+              value={roster[pos]}
+              onChange={(e) => {
+                const ids = Array.from(e.target.selectedOptions).map((o) => o.value)
+                setPos(pos, ids)
+              }}
+            >
+              {grouped[pos].map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-gray-500 mt-1">여러 명은 Ctrl/⌘ 클릭으로 선택</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="my-20 flex gap-5 justify-evenly">
+        <Button className="flex-1 py-2" size="lg" variant="secondary" onClick={onBack}>
+          이전
+        </Button>
+        <Button className="flex-1 py-2" size="lg" variant="secondary" onClick={onClose}>
+          취소
+        </Button>
+        <Button
+          className="flex-1 text-white py-2"
+          size="lg"
+          variant="primary"
+          disabled={!isValid}
+          onClick={handleNext}
+        >
+          다음
+        </Button>
+      </div>
+    </div>
+  )
 }

--- a/src/components/common/modal-contents/PostRosterContent.tsx
+++ b/src/components/common/modal-contents/PostRosterContent.tsx
@@ -1,0 +1,3 @@
+export default function PostRosterContent() {
+  return <div>두번째 모달</div>
+}

--- a/src/components/common/modal-contents/PostRosterContent.tsx
+++ b/src/components/common/modal-contents/PostRosterContent.tsx
@@ -55,14 +55,14 @@ export default function PostRosterContent({
 
   return (
     <div className="px-15 py-10 w-350 md:w-400">
-      <h2 className="text-lg font-bold mb-4 text-center">경기 등록 · 참석자/포메이션</h2>
+      <h2 className="text-lg font-bold mb-4 text-center">참석자 / 포메이션</h2>
 
-      <div className="flex flex-col gap-16">
+      <div className="flex flex-col gap-10">
         {/* 포메이션 */}
         <div>
           <label className="block mb-1 text-sm font-medium">포메이션</label>
           <select
-            className="w-full border rounded p-2"
+            className="w-full card-shadow border border-gray-300 rounded-[16px] p-2"
             value={formation}
             onChange={(e) => setFormation(e.target.value as Formation)}
           >
@@ -72,7 +72,6 @@ export default function PostRosterContent({
               </option>
             ))}
           </select>
-          <p className="text-xs text-gray-500 mt-1">GK는 최소 1명을 선택해 주세요.</p>
         </div>
 
         {/* 포지션별 멀티선택 */}
@@ -81,7 +80,7 @@ export default function PostRosterContent({
             <label className="block mb-1 text-sm font-medium">{pos}</label>
             <select
               multiple
-              className="w-full border rounded p-2 min-h-[96px]"
+              className="w-full card-shadow border border-gray-300 rounded-[16px] p-10 min-h-[60px]"
               value={roster[pos]}
               onChange={(e) => {
                 const ids = Array.from(e.target.selectedOptions).map((o) => o.value)

--- a/src/components/common/modal-contents/PostRosterContent.tsx
+++ b/src/components/common/modal-contents/PostRosterContent.tsx
@@ -62,7 +62,7 @@ export default function PostRosterContent({
         <div>
           <label className="block mb-1 text-sm font-medium">포메이션</label>
           <select
-            className="w-full card-shadow border border-gray-300 rounded-[16px] p-2"
+            className="w-full card-shadow border border-gray-100 rounded-[16px] p-10"
             value={formation}
             onChange={(e) => setFormation(e.target.value as Formation)}
           >
@@ -80,7 +80,7 @@ export default function PostRosterContent({
             <label className="block mb-1 text-sm font-medium">{pos}</label>
             <select
               multiple
-              className="w-full card-shadow border border-gray-300 rounded-[16px] p-10 min-h-[60px]"
+              className="w-full card-shadow border border-gray-100 rounded-[16px] p-10 min-h-[60px]"
               value={roster[pos]}
               onChange={(e) => {
                 const ids = Array.from(e.target.selectedOptions).map((o) => o.value)
@@ -93,7 +93,6 @@ export default function PostRosterContent({
                 </option>
               ))}
             </select>
-            <p className="text-xs text-gray-500 mt-1">여러 명은 Ctrl/⌘ 클릭으로 선택</p>
           </div>
         ))}
       </div>

--- a/src/components/common/modal-contents/PostScoresContent.tsx
+++ b/src/components/common/modal-contents/PostScoresContent.tsx
@@ -1,0 +1,3 @@
+export default function PostScoresContent() {
+  return <div>득점자도움자컴포넌트</div>
+}

--- a/src/components/common/modal-contents/PostScoresContent.tsx
+++ b/src/components/common/modal-contents/PostScoresContent.tsx
@@ -1,3 +1,103 @@
-export default function PostScoresContent() {
-  return <div>득점자도움자컴포넌트</div>
+'use client'
+
+import { useState } from 'react'
+import Button from '@/components/common/Button'
+import type { PostScoresContentProps, QuarterData, GoalEvent } from '@/constants/modal'
+
+export default function PostScoresContent({
+  onBack,
+  onClose,
+  onSubmit,
+  initial = [],
+  eligiblePlayers,
+}: PostScoresContentProps) {
+  const [quarters, setQuarters] = useState<QuarterData[]>(initial)
+
+  const addGoal = (qi: number) => {
+    const goals = [...quarters[qi].goals, { scorerId: '', assistId: null }]
+    update(qi, { goals })
+  }
+
+  const updateGoal = (qi: number, gi: number, patch: Partial<GoalEvent>) => {
+    const goals = quarters[qi].goals.map((g, i) => (i === gi ? { ...g, ...patch } : g))
+    update(qi, { goals })
+  }
+
+  const removeGoal = (qi: number, gi: number) => {
+    const goals = quarters[qi].goals.filter((_, i) => i !== gi)
+    update(qi, { goals })
+  }
+
+  const update = (qi: number, patch: Partial<QuarterData>) => {
+    setQuarters((prev) => prev.map((q, i) => (i === qi ? { ...q, ...patch } : q)))
+  }
+
+  return (
+    <div className="px-15 py-10 w-350 md:w-400">
+      <h2 className="text-lg font-bold mb-4 text-center">득점 / 도움자 등록</h2>
+      {quarters.map((q, qi) => (
+        <div key={qi} className="border border-gray-100 rounded-[16px] p-8 my-6">
+          <div className="flex items-center py-5 justify-between">
+            <div className="font-semibold">
+              {qi + 1} 쿼터 (스코어 {q.scoreAfter})
+            </div>
+            <Button size="sm" variant="primary" onClick={() => addGoal(qi)}>
+              추가
+            </Button>
+          </div>
+
+          {q.goals.map((g, gi) => (
+            <div key={gi} className="flex flex-row gap-20 justify-center items-center mb-2">
+              <select
+                className="border border-gray-100 w-100 rounded-[12px] p-2"
+                value={g.scorerId}
+                onChange={(e) => updateGoal(qi, gi, { scorerId: e.target.value })}
+              >
+                <option value="">득점</option>
+                {eligiblePlayers.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+              <select
+                className="border border-gray-100 w-100 rounded-[12px] p-2"
+                value={g.assistId ?? ''}
+                onChange={(e) => updateGoal(qi, gi, { assistId: e.target.value || null })}
+              >
+                <option value="">도움</option>
+                {eligiblePlayers.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+              <div className="w-80 py-2">
+                <Button size="xs" variant="secondary" onClick={() => removeGoal(qi, gi)}>
+                  삭제
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      ))}
+
+      <div className="mt-10 flex gap-5 justify-evenly">
+        <Button className="flex-1" size="lg" variant="secondary" onClick={onBack}>
+          이전
+        </Button>
+        <Button className="flex-1" size="lg" variant="secondary" onClick={onClose}>
+          취소
+        </Button>
+        <Button
+          className="flex-1 text-white"
+          size="lg"
+          variant="primary"
+          onClick={() => onSubmit(quarters)}
+        >
+          완료
+        </Button>
+      </div>
+    </div>
+  )
 }

--- a/src/constants/modal.ts
+++ b/src/constants/modal.ts
@@ -5,6 +5,7 @@ import { WarningContent } from '@/components/common/modal-contents/WarningConten
 import { EventsType } from '@/mocks/calenderEvents'
 import PostRosterContent from '@/components/common/modal-contents/PostRosterContent'
 import PostQuartersContent from '@/components/common/modal-contents/PostQuartersContent'
+import PostScoresContent from '@/components/common/modal-contents/PostScoresContent'
 
 type ContentMapType = {
   [V in ModalVariant]: React.FC<Extract<ModalProps, { variant: V }>>
@@ -17,6 +18,7 @@ export const ContentMap: ContentMapType = {
   scheduleEvent: ScheduleContent,
   postRoster: PostRosterContent,
   postQuarters: PostQuartersContent,
+  postScores: PostScoresContent,
 } as const
 
 export type ModalVariant =
@@ -26,6 +28,7 @@ export type ModalVariant =
   | 'scheduleEvent'
   | 'postRoster'
   | 'postQuarters'
+  | 'postScores'
 
 export type Position = 'GK' | 'DF' | 'MF' | 'FW'
 export type Formation = '4-4-2' | '4-2-3-1'
@@ -97,6 +100,15 @@ export interface PostQuartersContentProps {
   initial?: QuarterData[]
 }
 
+export interface PostScoresContentProps {
+  variant: 'postScores'
+  onBack: () => void
+  onClose: () => void
+  onSubmit: (data: QuarterData[]) => void
+  initial?: QuarterData[]
+  eligiblePlayers: { id: string; name: string }[]
+}
+
 export type ModalProps =
   | OnlyTextModalProps
   | WarningModalProps
@@ -104,3 +116,4 @@ export type ModalProps =
   | ScheduleContentProps
   | PostRosterContentProps
   | PostQuartersContentProps
+  | PostScoresContentProps

--- a/src/constants/modal.ts
+++ b/src/constants/modal.ts
@@ -3,6 +3,8 @@ import { PostMatchContent } from '@/components/common/modal-contents/PostMatchCo
 import ScheduleContent from '@/components/common/modal-contents/ScheduleContent'
 import { WarningContent } from '@/components/common/modal-contents/WarningContent'
 import { EventsType } from '@/mocks/calenderEvents'
+import PostRosterContent from '@/components/common/modal-contents/PostRosterContent'
+import PostQuartersContent from '@/components/common/modal-contents/PostQuartersContent'
 
 type ContentMapType = {
   [V in ModalVariant]: React.FC<Extract<ModalProps, { variant: V }>>
@@ -13,9 +15,28 @@ export const ContentMap: ContentMapType = {
   warning: WarningContent,
   postMatch: PostMatchContent,
   scheduleEvent: ScheduleContent,
+  postRoster: PostRosterContent,
+  postQuarters: PostQuartersContent,
 } as const
 
-export type ModalVariant = 'onlyText' | 'warning' | 'postMatch' | 'scheduleEvent'
+export type ModalVariant =
+  | 'onlyText'
+  | 'warning'
+  | 'postMatch'
+  | 'scheduleEvent'
+  | 'postRoster'
+  | 'postQuarters'
+
+export type Position = 'GK' | 'DF' | 'MF' | 'FW'
+export type Formation = '4-4-2' | '4-2-3-1'
+
+export type RosterData = {
+  formation: Formation
+  GK: string[]
+  DF: string[]
+  MF: string[]
+  FW: string[]
+}
 
 export type PostMatchData = {
   date: string
@@ -23,6 +44,9 @@ export type PostMatchData = {
   place: string
   score: string
 }
+
+export type GoalEvent = { scorerId: string; assistId?: string | null }
+export type QuarterData = { goals: GoalEvent[]; conceded: number; scoreAfter: string }
 
 export interface OnlyTextModalProps {
   variant: 'onlyText'
@@ -42,13 +66,35 @@ export interface WarningModalProps {
 export interface PostMatchProps {
   variant: 'postMatch'
   onClose: () => void
-  onSubmit: (data: { date: string; opponent: string; place: string; score: string }) => void
+  onSubmit: (data: PostMatchData) => void
 }
 
 export interface ScheduleContentProps {
   variant: 'scheduleEvent'
   onClose: () => void
   onSubmit: (data: { date: string; type: EventsType; title?: string; place?: string }) => void
+}
+
+export interface PostRosterContentProps {
+  variant: 'postRoster'
+  onBack: () => void
+  onClose: () => void
+  // “다음” 누르면 참가자/포메이션 전달
+  onSubmit: (data: RosterData) => void
+  // 플레이어 소스 (id/name/position) 를 상위에서 주입
+  players: { id: string; name: string; position: Position }[]
+  // 필요하다면 초기값(수정 플로우) 지원
+  initial?: RosterData
+}
+
+export interface PostQuartersContentProps {
+  variant: 'postMatchQuarters'
+  onBack: () => void
+  onClose: () => void
+  onSubmit: (data: QuarterData[]) => void
+  // 2단계에서 선택된 선수들만 득점/도움 후보로
+  eligiblePlayers: { id: string; name: string }[]
+  initial?: QuarterData[]
 }
 
 export type ModalProps =

--- a/src/constants/modal.ts
+++ b/src/constants/modal.ts
@@ -88,7 +88,7 @@ export interface PostRosterContentProps {
 }
 
 export interface PostQuartersContentProps {
-  variant: 'postMatchQuarters'
+  variant: 'postQuarters'
   onBack: () => void
   onClose: () => void
   onSubmit: (data: QuarterData[]) => void
@@ -102,3 +102,5 @@ export type ModalProps =
   | WarningModalProps
   | PostMatchProps
   | ScheduleContentProps
+  | PostRosterContentProps
+  | PostQuartersContentProps

--- a/src/mocks/QuarterScores.ts
+++ b/src/mocks/QuarterScores.ts
@@ -45,7 +45,7 @@ export const sampleMatch: MatchSummary = {
     {
       label: '4 쿼터',
       goals: ['신성오', '신성오'],
-      assists: ['현신우'],
+      assists: ['현신우', '유동엽'],
       conceded: 0,
       scoreAfter: '5 - 3',
     },


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->

경기등록에 필요한 과정을 모달형태로 구현했습니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

### `app/components/common/modal-contents` 폴더에 저장중입니다.

`PostMatchContent.tsx` : 경기일, 장소, 전체 스코어, 상대팀 을 등록하는 모달입니다.
`PostRosterContent.tsx` : 참석인원과 포메이션을 고를 수 있는 모달입니다.
`PostQuartersContent.tsx` : 쿼터별 스코어와 실점횟수를 등록하는 모달입니다.
`PostScoresContent.tsx` : 쿼터별 득점자와 도움자, 를 등록하는 모달입니다.

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
#40 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

### `PostMatchContent.tsx`

<img width="318" height="621" alt="스크린샷 2025-09-09 오후 2 34 12" src="https://github.com/user-attachments/assets/a6cef196-adc6-4a3e-9672-6e8b25bf4500" />


### `PostRosterContent.tsx`

<img width="321" height="666" alt="스크린샷 2025-09-09 오후 2 34 25" src="https://github.com/user-attachments/assets/d1fcc6e2-b848-42ef-a7d0-a0aa0a8c14a8" />


### `PostQuartersContent.tsx`

<img width="316" height="582" alt="스크린샷 2025-09-09 오후 2 34 51" src="https://github.com/user-attachments/assets/e7921a67-f29f-4b8f-ab8d-10899733e8a8" />


### `PostScoresContent.tsx`

<img width="320" height="545" alt="스크린샷 2025-09-09 오후 2 35 21" src="https://github.com/user-attachments/assets/ee63c7bd-942b-4572-8cfe-c1a0dde14d18" />


## 💡 참고 사항

아직 supabase api 호출을 할 수 없는 상태라 임시 데이터로 적용했습니다.
추후 issue 에서 api 호출을 할 수 있는 기능을 구현할 예정입니다.