### PR TITLE
Design - 64 : 선수관리 페이지 UI 수정

### DIFF
--- a/src/app/players/page.tsx
+++ b/src/app/players/page.tsx
@@ -4,9 +4,9 @@ import { useQuery } from '@tanstack/react-query'
 import { getPlayers } from '@/libs/playersApi'
 import type { Player } from '@/libs/playersApi'
 import PlayerCard from '@/components/players/PlayerCard'
+import PlayerCardSkeleton from '@/components/players/PlayerCardSkeleton'
 import { Position } from '@/constants/positionColor'
 import FirstPrize from '@/components/players/FirstPrize'
-import Spinner from '@/components/common/spinner/Spinner'
 
 const POSITION_LABEL: Record<Position, string> = {
   GK: 'GK',
@@ -25,12 +25,28 @@ export default function PlayersPage() {
 
   const positions: Position[] = ['FW', 'MF', 'DF', 'GK']
 
-  if (isLoading)
+  if (isLoading) {
     return (
-      <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60">
-        <Spinner />
-      </div>
+      <>
+        <FirstPrize />
+        <main className="bg-sub-gray rounded-b-[16px] space-y-12 py-10 px-20 md:px-40">
+          {positions.map((pos) => (
+            <section key={pos}>
+              <h2 className="mb-4 text-[30px] md:text-[60px] font-bold text-gray-800">
+                {POSITION_LABEL[pos]}
+              </h2>
+              <div className="grid grid-cols-3 md:grid-cols-5 gap-10 md:gap-20">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <PlayerCardSkeleton key={i} />
+                ))}
+              </div>
+            </section>
+          ))}
+        </main>
+      </>
     )
+  }
+
   if (isError) return <main className="p-20 text-red-500">데이터 불러오기 실패</main>
 
   return (

--- a/src/components/players/FirstPrize.tsx
+++ b/src/components/players/FirstPrize.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image'
 import { useQuery } from '@tanstack/react-query'
 import { getPlayers, type Player } from '@/libs/playersApi'
+import FirstPrizeSkeleton from './FirstPrizeSkeleton'
 
 const EXCLUDED_PLAYERS = ['제갈진석', '차우현']
 
@@ -44,7 +45,7 @@ export default function FirstPrize() {
     staleTime: 0,
   })
 
-  if (isLoading) return <p className="text-center py-20">불러오는 중…</p>
+  if (isLoading) return <FirstPrizeSkeleton />
   if (isError || !data)
     return <p className="text-center py-20 text-red-500">데이터를 불러오지 못했습니다.</p>
 

--- a/src/components/players/FirstPrizeSkeleton.tsx
+++ b/src/components/players/FirstPrizeSkeleton.tsx
@@ -1,0 +1,24 @@
+import Skeleton from '@/components/common/skeleton/Skeleton'
+
+export default function FirstPrizeSkeleton() {
+  return (
+    <section className="bg-sub-gray rounded-t-[16px] py-10">
+      <div className="bg-white m-20 rounded-[16px]">
+        <div className="text-center pt-10 mb-15">
+          <Skeleton className="h-[30px] md:h-[60px] w-[120px] md:w-[200px] mx-auto mb-2" />
+          <Skeleton className="h-[30px] md:h-[60px] w-[100px] md:w-[180px] mx-auto" />
+        </div>
+        <article className="text-center flex flex-row p-15 justify-center items-center gap-50">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex flex-col gap-5">
+              <Skeleton className="h-60 w-60 md:h-80 md:w-80 rounded-full mx-auto" />
+              <Skeleton className="h-[16px] md:h-[24px] w-[48px] md:w-[64px] mx-auto" />
+              <Skeleton className="h-[20px] md:h-[32px] w-[60px] md:w-[100px] mx-auto mt-10" />
+              <Skeleton className="h-[14px] md:h-[18px] w-[40px] md:w-[60px] mx-auto" />
+            </div>
+          ))}
+        </article>
+      </div>
+    </section>
+  )
+}

--- a/src/components/players/PlayerCardSkeleton.tsx
+++ b/src/components/players/PlayerCardSkeleton.tsx
@@ -1,0 +1,26 @@
+import Skeleton from '@/components/common/skeleton/Skeleton'
+
+export default function PlayerCardSkeleton() {
+  return (
+    <section className="aspect-square w-full card-shadow">
+      <Skeleton className="h-110 md:h-160 rounded-t-[24px]" />
+      <div className="-mt-30 p-10 md:p-15 h-110 md:h-160 rounded-[24px] bg-white shadow-md">
+        <Skeleton className="h-[14px] md:h-[22px] w-[60px] md:w-[80px] mx-auto mb-4" />
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between px-2">
+            <Skeleton className="h-[12px] md:h-[16px] w-[32px] md:w-[40px]" />
+            <Skeleton className="h-[12px] md:h-[16px] w-[16px] md:w-[24px]" />
+          </div>
+          <div className="flex items-center justify-between px-2">
+            <Skeleton className="h-[12px] md:h-[16px] w-[32px] md:w-[40px]" />
+            <Skeleton className="h-[12px] md:h-[16px] w-[16px] md:w-[24px]" />
+          </div>
+          <div className="flex items-center justify-between px-2">
+            <Skeleton className="h-[12px] md:h-[16px] w-[40px] md:w-[48px]" />
+            <Skeleton className="h-[12px] md:h-[16px] w-[24px] md:w-[32px]" />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->

선수관리 페이지의 UI 를 개선합니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

- 부문별 1위를 보여주는 컴포넌트의 UI 를 개선합니다.
- 선수관리 페이지에도 스켈레톤UI 를 적용하여 UX를 개선합니다.

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
#64 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## 변경 전

<img width="294" height="437" alt="스크린샷 2025-12-03 오후 3 59 10" src="https://github.com/user-attachments/assets/e12682c8-7c4e-4c55-8493-536177a0ee51" />


## 변경 후

<img width="295" height="461" alt="스크린샷 2025-12-03 오후 3 58 59" src="https://github.com/user-attachments/assets/7df62b8c-01e3-4ec7-927b-1269720ac1e2" />


## 💡 참고 사항
