### PR TITLE
bug - 콜론 삭제

### DIFF
--- a/src/entities/match/ui/MatchCard.tsx
+++ b/src/entities/match/ui/MatchCard.tsx
@@ -63,15 +63,9 @@ export default function MatchCard({ match }: MatchCardProps) {
                   <p className="mb-1 text-[10px] font-black uppercase tracking-[0.3em] text-gray-500">
                     최종 스코어
                   </p>
-                  <div className="flex items-center gap-3">
-                    <span className="text-4xl font-black leading-none tracking-tighter text-white md:text-5xl">
-                      {match.score.split(':')[0]}
-                    </span>
-                    <span className="text-xl font-black text-white">:</span>
-                    <span className="text-4xl font-black leading-none tracking-tighter text-white md:text-5xl">
-                      {match.score.split(':')[1]}
-                    </span>
-                  </div>
+                  <span className="text-4xl font-black leading-none tracking-tighter text-white md:text-5xl">
+                    {match.score.replace(':', '-')}
+                  </span>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
경기 최종 스코어를 보여주는 MatchCard.tsx 에서 2-0: 같은 식으로 끝에 콜론이 보여지는 현상을 수정합니다.

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
#84 

## 🖼️ 스크린샷(선택사항)

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->
변경 전

<img width="196" height="162" alt="스크린샷 2026-03-02 오후 5 58 15" src="https://github.com/user-attachments/assets/eb1e4433-c063-4d15-abff-f60bd9315687" />

변경 후

<img width="191" height="179" alt="스크린샷 2026-03-02 오후 5 58 24" src="https://github.com/user-attachments/assets/853553b9-0b85-4407-8146-9443fb08072e" />



## 💡 참고 사항
